### PR TITLE
Issue #13: Add stress test for 100+ concurrent 4-player games

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,11 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not stress'"
 asyncio_mode = "auto"
+markers = [
+    "stress: heavyweight stress tests (deselected by default, run with -m stress)",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -88,6 +88,50 @@ class TestConcurrentGames:
         assert finished == 20, f"Only {finished}/20 games finished"
         await manager.cleanup()
 
+    @pytest.mark.stress
+    @pytest.mark.asyncio
+    async def test_100_concurrent_4_player_games(self):
+        """Stress: 100 simultaneous 4-player games all run to completion."""
+        num_games = 100
+        manager = GameManager()
+        game_ids: list[str] = []
+        host_tokens: list[str] = []
+
+        for i in range(num_games):
+            game = manager.create_game(
+                player_count=4,
+                tick_rate_ms=10,
+                client_ip=f"stress-{i % 50}",
+            )
+            game_ids.append(game.game_id)
+
+            tokens = []
+            for j in range(4):
+                slot = manager.join_game(game.game_id, f"p{j}-g{i}")
+                tokens.append(slot.token)
+            host_tokens.append(tokens[0])
+
+        for gid, token in zip(game_ids, host_tokens, strict=True):
+            manager.start_game(gid, token)
+
+        for _ in range(600):
+            await asyncio.sleep(0.05)
+            statuses = [
+                manager.get_game(gid).status.value for gid in game_ids
+            ]
+            if all(s == "finished" for s in statuses):
+                break
+
+        finished = sum(
+            1
+            for gid in game_ids
+            if manager.get_game(gid).status.value == "finished"
+        )
+        assert finished == num_games, (
+            f"Only {finished}/{num_games} games finished"
+        )
+        await manager.cleanup()
+
     @pytest.mark.asyncio
     async def test_rate_limiting(self):
         """Verify rate limiter blocks excessive creation from one IP."""


### PR DESCRIPTION
Closes #13

## Summary

Adds an optionally-skipped stress test that exercises 100 simultaneous 4-player games through the `GameManager`, validating the server's stated concurrency target.

### What changed
- **`pyproject.toml`**: Registered a `stress` pytest marker; default `addopts` excludes it (`-m 'not stress'`) so normal CI runs are unaffected.
- **`tests/test_load.py`**: Added `test_100_concurrent_4_player_games` — creates 100 games with 4 players each, starts all tick loops, and asserts every game finishes.

### Why
Existing load tests (50×2-player, 20×mixed) validated concurrency but did not reach the 100+ concurrent 4-player envelope called out in the PR #11 merge gate review.

### Key decisions
- Used `@pytest.mark.stress` with default deselection via `addopts` rather than `skipUnless(env)` — cleaner opt-in via `pytest -m stress`.
- Rate-limit IPs are spread across 50 unique values to stay within the 10-per-IP limit.
- 30-second polling ceiling (600 × 50ms) gives plenty of headroom; the test typically completes in ~2s.

## Test plan
- [x] `make check` passes (235 tests, lint clean, stress test correctly deselected)
- [x] `pytest -m stress` runs and passes the new test

[github-buddy]